### PR TITLE
docs: redirect to cloud-native-ecommerce-platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+> [!IMPORTANT]
+> **This repository is the foundation for a newer, actively maintained project.**
+>
+> Development has moved to **[cloud-native-ecommerce-platform](https://github.com/sloweyyy/cloud-native-ecommerce-platform)**, which builds on this codebase with .NET 8 upgrades, React/Nx microfrontends, expanded data stores (MongoDB, Redis, PostgreSQL, SQL Server), RabbitMQ, an Ocelot API gateway, and Kubernetes-ready deployments.
+>
+> Please head over to the new repo for the latest features, fixes, and documentation: **<https://github.com/sloweyyy/cloud-native-ecommerce-platform>**
+
+---
+
 # .NET Core Microservices E-commerce Project
 
 ## Overview


### PR DESCRIPTION
## Summary
- Add a banner at the top of the README pointing users to the actively maintained successor project: [`sloweyyy/cloud-native-ecommerce-platform`](https://github.com/sloweyyy/cloud-native-ecommerce-platform).
- The original content is preserved below the banner so the repo still works as historical reference.

## Test plan
- [ ] Confirm the banner renders correctly on GitHub's README view.
- [ ] Verify the link to the new repo resolves.