### PR TITLE
docs: update redirect note with cloud-native-ecommerce-platform's current stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
 > [!IMPORTANT]
 > **This repository is the foundation for a newer, actively maintained project.**
 >
-> Development has moved to **[cloud-native-ecommerce-platform](https://github.com/sloweyyy/cloud-native-ecommerce-platform)**, which builds on this codebase with .NET 8 upgrades, React/Nx microfrontends, expanded data stores (MongoDB, Redis, PostgreSQL, SQL Server), RabbitMQ, an Ocelot API gateway, and Kubernetes-ready deployments.
+> Development has moved to **[cloud-native-ecommerce-platform](https://github.com/sloweyyy/cloud-native-ecommerce-platform)**, which builds on this codebase and now ships:
 >
-> Please head over to the new repo for the latest features, fixes, and documentation: **<https://github.com/sloweyyy/cloud-native-ecommerce-platform>**
+> - **.NET 10 LTS** across all services (supported through 2028-11)
+> - **React + Nx Module Federation** microfrontends (the original Angular UI lives on under `/client`)
+> - **AWS EKS** deployment provisioned via **Terraform**, fronted by **Istio** service mesh with mTLS
+> - **Riok.Mapperly** (source-generated mapping) and an in-house mediator replacing AutoMapper and MediatR — the original library versions had a HIGH-severity CVE and moved to commercial licensing
+> - Expanded data stores: MongoDB, Redis, PostgreSQL, SQL Server, AWS S3
+> - **RabbitMQ + MassTransit 8.x** event bus, **Ocelot** API gateway
+> - **OpenTelemetry + Jaeger** tracing, **Prometheus + Grafana** metrics, **ELK** logs
+> - **Central Package Management** with transitive pinning, zero known CVE warnings on restore
+>
+> Head over to the new repo for the latest features, fixes, and documentation: **<https://github.com/sloweyyy/cloud-native-ecommerce-platform>**
 
 ---
 


### PR DESCRIPTION
## Summary

Refreshes the top-of-README pointer to the successor repo with the post-modernization stack. The previous note still said *.NET 8* + a short feature list — out of date after the recent modernization wave on `cloud-native-ecommerce-platform`.

## What's now mentioned

- **.NET 10 LTS** (supported through Nov 2028). .NET 8 LTS ends Nov 2026; .NET 9 STS already EOL'd in May 2026, so the new repo skipped it.
- **AWS EKS** deployment via **Terraform**, fronted by **Istio** with mTLS.
- **Riok.Mapperly** (source-generated) and an **in-house mediator** replacing AutoMapper + MediatR — both went commercial in 2024, and AutoMapper 13.x carried [CVE-2026-32933](https://github.com/advisories/GHSA-rvv3-g6hj-g44x) (HIGH).
- **MassTransit 8.x** across all services.
- **OpenTelemetry + Jaeger** traces, **Prometheus + Grafana** metrics, **ELK** logs.
- **Central Package Management** with transitive pinning; `dotnet restore` reports zero NU190x CVE warnings.

## Out of scope

No code changes — just the redirect note. The rest of this README describes this repo's foundational state (which DID use AutoMapper, MediatR, .NET 6/7, etc.) and stays accurate.